### PR TITLE
Fixed typo in $service_ensure enum

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -43,7 +43,7 @@ class jetty(
   Stdlib::Absolutepath      $base,
   String                    $version,
   Optional[String]          $service_name,
-  Enum['running', 'stoped'] $service_ensure,
+  Enum['running', 'stopped'] $service_ensure,
   Boolean                   $manage_user,
   String                    $user,
   String                    $group,


### PR DESCRIPTION
As per the summary, nothing else to add!